### PR TITLE
Fix right-click map provider not working in Qt6

### DIFF
--- a/showOnMapTool.py
+++ b/showOnMapTool.py
@@ -56,6 +56,8 @@ class ShowOnMapTool(QgsMapToolEmitPoint):
             self.removeMarker()
 
         button = event.button()
+        if not isinstance(button, int):
+            button = button.value
 
         canvasCRS = self.canvas.mapSettings().destinationCrs()
         transform = QgsCoordinateTransform(canvasCRS, epsg4326, QgsProject.instance())


### PR DESCRIPTION
In PyQt6, Qt.MouseButton is enum.Flag and does not support comparison with integers, causing button == 2 to always be False for right-clicks. As a result, right-clicking the map always uses the left-click provider.

Convert the enum to its integer value via .value when the button is not a direct int subclass, which is compatible with both Qt5 and Qt6.