### PR TITLE
Accept DMS input for geographic project and custom CRSs

### DIFF
--- a/digitizer.py
+++ b/digitizer.py
@@ -17,7 +17,7 @@ from qgis.PyQt.QtWidgets import QDialog, QMenu
 from qgis.PyQt.uic import loadUiType
 from qgis.core import Qgis, QgsCoordinateReferenceSystem, QgsCoordinateTransform, QgsVectorDataProvider, QgsGeometry, QgsPointXY, QgsJsonUtils, QgsWkbTypes, QgsProject, QgsSettings
 from qgis.gui import QgsProjectionSelectionDialog
-from .util import epsg4326, parseDMSString, tr
+from .util import epsg4326, parseCoordinateString, tr
 # import traceback
 
 from . import mgrs
@@ -119,7 +119,7 @@ class DigitizerWidget(QDialog, FORM_CLASS):
                     lon = float(m[0][0])
                     lat = float(m[0][1])
                 else:
-                    lat, lon = parseDMSString(text, self.inputXYOrder)
+                    lat, lon = parseCoordinateString(text, epsg4326, self.inputXYOrder)
                 srcCrs = epsg4326
             elif self.inputProjection == 1:
                 # This is an MGRS coordinate
@@ -139,26 +139,18 @@ class DigitizerWidget(QDialog, FORM_CLASS):
                 lon = pt.x()
                 srcCrs = epsg4326
             else:  # Is either the project or custom CRS
+                if self.inputProjection == 2:  # Project CRS
+                    srcCrs = self.canvas.mapSettings().destinationCrs()
+                else:
+                    srcCrs = QgsCoordinateReferenceSystem(self.inputCustomCRS)
                 if re.search(r'POINT\(', text) is None:
-                    coords = re.split(r'[\s,;:]+', text, 1)
-                    if len(coords) < 2:
-                        raise ValueError('Invalid Coordinates')
-                    if self.inputXYOrder == 0:  # Y, X Order
-                        lat = float(coords[0])
-                        lon = float(coords[1])
-                    else:
-                        lon = float(coords[0])
-                        lat = float(coords[1])
+                    lat, lon = parseCoordinateString(text, srcCrs, self.inputXYOrder)
                 else:
                     m = re.findall(r'POINT\(\s*([+-]?\d*\.?\d*)\s+([+-]?\d*\.?\d*)', text)
                     if len(m) != 1:
                         raise ValueError(tr('Invalid Coordinates'))
                     lon = float(m[0][0])
                     lat = float(m[0][1])
-                if self.inputProjection == 2:  # Project CRS
-                    srcCrs = self.canvas.mapSettings().destinationCrs()
-                else:
-                    srcCrs = QgsCoordinateReferenceSystem(self.inputCustomCRS)
         except Exception:
             # traceback.print_exc()
             self.iface.messageBar().pushMessage("", tr("Invalid Coordinate"), level=Qgis.MessageLevel.Warning, duration=2)

--- a/index.html
+++ b/index.html
@@ -156,6 +156,7 @@ code {
 <li><img src="images/customProjection.svg" alt="Custome Projection"> <strong><em>New/Custom Projection</em></strong> - This allows the user to select any projection for the input coordinates.</li>
 <li><img src="images/pluscodes.svg" alt="Plus Codes"> <strong><em>Plus Codes Coordinate</em></strong> - This specifies a Plus Code coordinate.</li>
 </ul>
+<p>Geographic project and custom CRSs accept coordinates in decimal degrees or DMS notation. Projected CRSs require numeric Y,X or X,Y coordinates.</p>
 <p>The next drop down menu specifies whether the coordinates are listed as <strong>Y,X (Latitude, Longitude)</strong> or <strong>X,Y (Longitude, Latitude)</strong>. If the coordinate uses <strong>N, S, E, W</strong> then these take presidence and this setting is ignored.</p>
 <ul>
 <li><img src="images/yx.svg" width=24 height=24 alt="Y, X"> <strong><em>Y,X (Latitude, Longitude) Order</em></strong></li>
@@ -292,8 +293,8 @@ code {
 <p>The <strong><em>Zoom to Latitude, Longitude</em></strong> tool accepts the following input coordinates as specified by <strong><em>Zoom to Coordinate Type</em></strong>:</p>
 <ul>
 <li><strong>WGS 84 (Latitude &amp; Longitude) / Auto Detect Format</strong> - Input coordinates can be either in decimal degrees, DMS degrees, WKT, or GeoJSON. For decimal and DMS formats, the order of the coordinates are determined by <strong><em>Zoom to Coordinate Order</em></strong>. It also auto detects MGRS, Plus Codes, Standard UTM, UPS, GEOREF, and Geohash formats so it is generally unnecessary to specify them separately.</li>
-<li><strong>Project CRS</strong> - This accepts coordinates formatted in the CRS of the QGIS project. The numbers can be formatted in decimal or WKT notation.</li>
-<li><strong>Custom CRS</strong> - You can specify any CRS for the input coordinates and QGIS zooms to that coordinate regardless of the project CRS. The numbers can be formatted in decimal or WKT notation.</li>
+<li><strong>Project CRS</strong> - This accepts coordinates formatted in the CRS of the QGIS project. Geographic project CRSs accept decimal degrees, DMS, or WKT notation. Projected project CRSs accept numeric coordinates or WKT notation.</li>
+<li><strong>Custom CRS</strong> - You can specify any CRS for the input coordinates and QGIS zooms to that coordinate regardless of the project CRS. Geographic custom CRSs accept decimal degrees, DMS, or WKT notation. Projected custom CRSs accept numeric coordinates or WKT notation.</li>
 <li><strong>MGRS</strong> - This only accepts <a href="https://en.wikipedia.org/wiki/Military_grid_reference_system">MGRS</a> coordinates as input.</li>
 <li><strong>Plus Codes</strong> - This only accepts <a href="https://plus.codes/">Plus Codes</a> coordinates as input.</li>
 <li><strong>Standard UTM</strong> - This only accepts <strong>Standard UTM</strong> coordinates as input.</li>

--- a/readme.md
+++ b/readme.md
@@ -111,6 +111,8 @@ A number of the conversions can be accessed as field calculator functions. When 
     * <img src="images/customProjection.svg" alt="Custome Projection"> ***New/Custom Projection*** - This allows the user to select any projection for the input coordinates.
     * <img src="images/pluscodes.svg" alt="Plus Codes"> ***Plus Codes Coordinate*** - This specifies a Plus Code coordinate.
     
+    Geographic project and custom CRSs accept coordinates in decimal degrees or DMS notation. Projected CRSs require numeric Y,X or X,Y coordinates.
+
     The next drop down menu specifies whether the coordinates are listed as **Y,X (Latitude, Longitude)** or **X,Y (Longitude, Latitude)**. If the coordinate uses **N, S, E, W** then these take presidence and this setting is ignored.
     
     * <img src="images/yx.svg" width=24 height=24 alt="Y, X"> ***Y,X (Latitude, Longitude) Order***
@@ -236,8 +238,8 @@ The order in which the coordinates are captured is determined by ***Coordinate o
 The ***Zoom to Latitude, Longitude*** tool accepts the following input coordinates as specified by ***Zoom to Coordinate Type***:
 
 * **WGS 84 (Latitude & Longitude) / Auto Detect Format** - Input coordinates can be either in decimal degrees, DMS degrees, WKT, or GeoJSON. For decimal and DMS formats, the order of the coordinates are determined by ***Zoom to Coordinate Order***. It also auto detects MGRS, Plus Codes, Standard UTM, UPS, GEOREF, and Geohash formats so it is generally unnecessary to specify them separately.
-* **Project CRS** - This accepts coordinates formatted in the CRS of the QGIS project. The numbers can be formatted in decimal or WKT notation.
-* **Custom CRS** - You can specify any CRS for the input coordinates and QGIS zooms to that coordinate regardless of the project CRS. The numbers can be formatted in decimal or WKT notation.
+* **Project CRS** - This accepts coordinates formatted in the CRS of the QGIS project. Geographic project CRSs accept decimal degrees, DMS, or WKT notation. Projected project CRSs accept numeric coordinates or WKT notation.
+* **Custom CRS** - You can specify any CRS for the input coordinates and QGIS zooms to that coordinate regardless of the project CRS. Geographic custom CRSs accept decimal degrees, DMS, or WKT notation. Projected custom CRSs accept numeric coordinates or WKT notation.
 * **MGRS** - This only accepts [MGRS](https://en.wikipedia.org/wiki/Military_grid_reference_system) coordinates as input.
 * **Plus Codes** - This only accepts [Plus Codes](https://plus.codes/) coordinates as input.
 * **Standard UTM** - This only accepts **Standard UTM** coordinates as input.

--- a/tests/test_coordinate_input.py
+++ b/tests/test_coordinate_input.py
@@ -1,0 +1,185 @@
+import importlib
+import os
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+import sys
+import unittest
+
+
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+from qgis.core import (  # noqa: E402
+    QgsApplication,
+    QgsCoordinateReferenceSystem,
+    QgsVectorDataProvider,
+)
+
+
+PLUGIN_DIR = Path(__file__).resolve().parents[1]
+PACKAGE_NAME = 'latlontools_test'
+PACKAGE = ModuleType(PACKAGE_NAME)
+PACKAGE.__path__ = [str(PLUGIN_DIR)]
+sys.modules[PACKAGE_NAME] = PACKAGE
+
+QGIS_APP = QgsApplication([], False)
+QGIS_APP.initQgis()
+
+ZOOM_MODULE = importlib.import_module(f'{PACKAGE_NAME}.zoomToLatLon')
+DIGITIZER_MODULE = importlib.import_module(f'{PACKAGE_NAME}.digitizer')
+
+
+class FakeSettings:
+
+    def __init__(self, mode, crs, order=0):
+        self.mode = mode
+        self.crs = crs
+        self.zoomToCoordOrder = order
+
+    def __getattr__(self, name):
+        if name.startswith('zoomToProjIs'):
+            selected = {
+                'zoomToProjIsWgs84': 'wgs84',
+                'zoomToProjIsProjectCRS': 'project',
+            }.get(name)
+            return lambda: selected == self.mode
+        raise AttributeError(name)
+
+    def zoomToCustomCRS(self):
+        return self.crs
+
+
+class FakeCanvas:
+
+    def __init__(self, crs):
+        self.crs = crs
+
+    def mapSettings(self):
+        return self
+
+    def destinationCrs(self):
+        return self.crs
+
+
+class FakeLineEdit:
+
+    def __init__(self, value):
+        self.value = value
+        self.cleared = False
+
+    def text(self):
+        return self.value
+
+    def clear(self):
+        self.cleared = True
+
+
+class FakeLayer:
+
+    def __init__(self, crs):
+        self._crs = crs
+
+    def dataProvider(self):
+        return self
+
+    def capabilities(self):
+        return QgsVectorDataProvider.Capability.AddFeatures
+
+    def crs(self):
+        return self._crs
+
+
+class FakeVectorLayerTools:
+
+    def __init__(self):
+        self.geometry = None
+
+    def addFeature(self, layer, attributes, geometry):
+        self.geometry = geometry
+        return True, None
+
+
+class FakeMessageBar:
+
+    def __init__(self):
+        self.messages = []
+
+    def pushMessage(self, *args, **kwargs):
+        self.messages.append((args, kwargs))
+
+
+class FakeInterface:
+
+    def __init__(self, layer):
+        self.layer = layer
+        self.layer_tools = FakeVectorLayerTools()
+        self.message_bar = FakeMessageBar()
+
+    def activeLayer(self):
+        return self.layer
+
+    def vectorLayerTools(self):
+        return self.layer_tools
+
+    def messageBar(self):
+        return self.message_bar
+
+
+class FakeLatLonTools:
+
+    def __init__(self):
+        self.zoom = None
+
+    def zoomTo(self, crs, y, x):
+        self.zoom = crs, y, x
+
+
+class GeographicCrsInputTest(unittest.TestCase):
+
+    def setUp(self):
+        self.crs = QgsCoordinateReferenceSystem('EPSG:4674')
+        self.coordinate = (
+            '10\N{DEGREE SIGN} 09\' 37.166" S, '
+            '056\N{DEGREE SIGN} 07\' 25.893" W'
+        )
+
+    def test_zoom_accepts_dms_in_project_geographic_crs(self):
+        subject = SimpleNamespace(
+            settings=FakeSettings('project', self.crs),
+            canvas=FakeCanvas(self.crs),
+        )
+
+        y, x, bounds, source_crs = ZOOM_MODULE.ZoomToLatLon.convertCoordinate(
+            subject, self.coordinate
+        )
+
+        self.assertAlmostEqual(y, -10.16032388888889)
+        self.assertAlmostEqual(x, -56.12385916666667)
+        self.assertIsNone(bounds)
+        self.assertEqual(source_crs.authid(), 'EPSG:4674')
+
+    def test_digitizer_adds_dms_point_in_project_geographic_crs(self):
+        layer = FakeLayer(self.crs)
+        iface = FakeInterface(layer)
+        line_edit = FakeLineEdit(self.coordinate)
+        lltools = FakeLatLonTools()
+        subject = SimpleNamespace(
+            inputProjection=2,
+            inputXYOrder=0,
+            canvas=FakeCanvas(self.crs),
+            iface=iface,
+            lineEdit=line_edit,
+            lltools=lltools,
+        )
+
+        DIGITIZER_MODULE.DigitizerWidget.addFeature(subject)
+
+        point = iface.layer_tools.geometry.asPoint()
+        self.assertAlmostEqual(point.y(), -10.16032388888889)
+        self.assertAlmostEqual(point.x(), -56.12385916666667)
+        self.assertTrue(line_edit.cleared)
+        self.assertEqual(iface.message_bar.messages, [])
+        self.assertEqual(lltools.zoom[0].authid(), 'EPSG:4674')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,82 @@
+import unittest
+import importlib.util
+from pathlib import Path
+
+from qgis.core import QgsCoordinateReferenceSystem
+
+
+PLUGIN_DIR = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location('latlontools_util', PLUGIN_DIR / 'util.py')
+UTIL = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(UTIL)
+
+
+class ParseCoordinateStringTest(unittest.TestCase):
+
+    def test_dms_in_non_wgs84_geographic_crs(self):
+        crs = QgsCoordinateReferenceSystem('EPSG:4674')
+
+        y, x = UTIL.parseCoordinateString(
+            '10\N{DEGREE SIGN} 09\' 37.166" S, '
+            '056\N{DEGREE SIGN} 07\' 25.893" W',
+            crs,
+            order=0,
+        )
+
+        self.assertAlmostEqual(y, -10.16032388888889)
+        self.assertAlmostEqual(x, -56.12385916666667)
+
+    def test_decimal_degrees_in_geographic_crs(self):
+        crs = QgsCoordinateReferenceSystem('EPSG:4674')
+
+        y, x = UTIL.parseCoordinateString(
+            '-10.16032388888889, -56.12385916666667', crs, order=0
+        )
+
+        self.assertAlmostEqual(y, -10.16032388888889)
+        self.assertAlmostEqual(x, -56.12385916666667)
+
+    def test_decimal_degrees_in_geographic_crs_xy_order(self):
+        crs = QgsCoordinateReferenceSystem('EPSG:4674')
+
+        y, x = UTIL.parseCoordinateString(
+            '-56.12385916666667, -10.16032388888889', crs, order=1
+        )
+
+        self.assertAlmostEqual(y, -10.16032388888889)
+        self.assertAlmostEqual(x, -56.12385916666667)
+
+    def test_numeric_coordinates_in_projected_crs_yx_order(self):
+        crs = QgsCoordinateReferenceSystem('EPSG:31981')
+
+        y, x = UTIL.parseCoordinateString(
+            '8876731.994, 595977.189', crs, order=0
+        )
+
+        self.assertAlmostEqual(y, 8876731.994)
+        self.assertAlmostEqual(x, 595977.189)
+
+    def test_numeric_coordinates_in_projected_crs_xy_order(self):
+        crs = QgsCoordinateReferenceSystem('EPSG:31981')
+
+        y, x = UTIL.parseCoordinateString(
+            '595977.189, 8876731.994', crs, order=1
+        )
+
+        self.assertAlmostEqual(y, 8876731.994)
+        self.assertAlmostEqual(x, 595977.189)
+
+    def test_dms_is_rejected_for_projected_crs(self):
+        crs = QgsCoordinateReferenceSystem('EPSG:31981')
+
+        with self.assertRaises(ValueError):
+            UTIL.parseCoordinateString(
+                '10\N{DEGREE SIGN} 09\' 37.166" S, '
+                '056\N{DEGREE SIGN} 07\' 25.893" W',
+                crs,
+                order=0,
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/util.py
+++ b/util.py
@@ -132,7 +132,7 @@ def parseDMSString(str, order=0):
             # There were no annotated dms coordinates so assume decimal degrees
             # Remove any characters that are not digits and decimal
             str = re.sub(r"[^\d.+-]+", " ", str).strip()
-            coords = re.split(r'\s+', str, 1)
+            coords = re.split(r'\s+', str, maxsplit=1)
             if len(coords) != 2:
                 raise ValueError('Invalid Coordinates')
             if order == 0:
@@ -182,6 +182,28 @@ def parseDMSString(str, order=0):
         raise ValueError('Invalid Coordinates')
 
     return lat, lon
+
+
+def parseCoordinateString(text, crs, order=0):
+    '''Parse a coordinate pair according to the units of its CRS.
+
+    Geographic CRSs accept decimal degrees or DMS notation. Projected CRSs
+    accept numeric coordinates only. The returned tuple is always (Y, X),
+    regardless of the input order.
+    '''
+    if crs.isGeographic():
+        return parseDMSString(text, order)
+
+    coords = re.split(r'[\s,;:]+', text.strip(), maxsplit=1)
+    if len(coords) != 2:
+        raise ValueError('Invalid Coordinates')
+    if order == 0:
+        y = float(coords[0])
+        x = float(coords[1])
+    else:
+        x = float(coords[0])
+        y = float(coords[1])
+    return y, x
 
 
 def parseDMSStringSingle(str):

--- a/zoomToLatLon.py
+++ b/zoomToLatLon.py
@@ -16,8 +16,8 @@ from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QDockWidget, QApplication, QMenu
 from qgis.gui import QgsRubberBand, QgsProjectionSelectionDialog
 from qgis.core import Qgis, QgsJsonUtils, QgsWkbTypes, QgsPointXY, QgsGeometry, QgsCoordinateReferenceSystem, QgsCoordinateTransform, QgsProject, QgsRectangle
-from .util import epsg4326, parseDMSString, tr
-from .settings import settings, CoordOrder, H3_INSTALLED
+from .util import epsg4326, parseCoordinateString, tr
+from .settings import settings, H3_INSTALLED
 from .utm import isUtm, utm2Point
 from .ups import isUps, ups2Point
 import traceback
@@ -277,25 +277,15 @@ class ZoomToLatLon(QDockWidget, FORM_CLASS):
                     srcCrs = self.settings.zoomToCustomCRS()
                 return (lat, lon, None, srcCrs)
 
-            # We are left with either DMS or decimal degrees in one of the projections
+            # Parse DMS or decimal degrees for geographic CRSs. Projected CRSs
+            # continue to require numeric coordinates.
             if self.settings.zoomToProjIsWgs84():
-                lat, lon = parseDMSString(text, self.settings.zoomToCoordOrder)
-                return (lat, lon, None, epsg4326)
-
-            # We are left with a non WGS 84 decimal projection
-            coords = re.split(r'[\s,;:]+', text, 1)
-            if len(coords) < 2:
-                raise ValueError(tr('Invalid Coordinates'))
-            if self.settings.zoomToCoordOrder == CoordOrder.OrderYX:
-                lat = float(coords[0])
-                lon = float(coords[1])
-            else:
-                lon = float(coords[0])
-                lat = float(coords[1])
-            if self.settings.zoomToProjIsProjectCRS():
+                srcCrs = epsg4326
+            elif self.settings.zoomToProjIsProjectCRS():
                 srcCrs = self.canvas.mapSettings().destinationCrs()
             else:
                 srcCrs = self.settings.zoomToCustomCRS()
+            lat, lon = parseCoordinateString(text, srcCrs, self.settings.zoomToCoordOrder)
             return (lat, lon, None, srcCrs)
 
         except Exception:


### PR DESCRIPTION
## Summary

- accept DMS and decimal-degree coordinate pairs whenever the selected input CRS is geographic, instead of limiting DMS parsing to EPSG:4326
- preserve numeric-only parsing for projected CRSs
- use the shared parser in both Zoom to Coordinate and Lat Lon Digitizing Tool
- document the supported formats for geographic and projected project/custom CRSs

## Reproduction

1. Set the project CRS to SIRGAS 2000 (`EPSG:4674`).
2. In Zoom to Coordinate or Lat Lon Digitizing Tool, select **Project CRS**.
3. Enter `10° 09' 37.166" S, 056° 07' 25.893" W`.

Before this change, the non-WGS84 branch passed the DMS fragments to `float()` and reported **Invalid Coordinate**. After this change, geographic CRSs use the existing DMS parser and retain the selected source CRS.

This also addresses the use case reported in the archived NationalSecurityAgency repository: https://github.com/NationalSecurityAgency/qgis-latlontools-plugin/issues/69

## Tests

`PYTHONDONTWRITEBYTECODE=1 QT_QPA_PLATFORM=offscreen python -m unittest discover -s tests -v`

Eight tests pass, covering:

- the reported DMS coordinate in `EPSG:4674`
- Zoom to Coordinate with a geographic project CRS
- point creation through Lat Lon Digitizing Tool
- decimal-degree Y,X and X,Y order
- projected `EPSG:31981` numeric Y,X and X,Y input
- rejection of DMS notation for a projected CRS